### PR TITLE
Configure prefixes for namespace in package-info.

### DIFF
--- a/app/src/main/java/org/lfenergy/compas/cim/mapping/rest/model/package-info.java
+++ b/app/src/main/java/org/lfenergy/compas/cim/mapping/rest/model/package-info.java
@@ -1,10 +1,16 @@
 // SPDX-FileCopyrightText: 2021 Alliander N.V.
 //
 // SPDX-License-Identifier: Apache-2.0
-@XmlSchema(xmlns = {@XmlNs(prefix = "cms", namespaceURI = CIM_MAPPING_SERVICE_NS_URI)})
+@XmlSchema(
+        xmlns = {
+                @XmlNs(prefix = "cms", namespaceURI = CIM_MAPPING_SERVICE_NS_URI),
+                @XmlNs(prefix = "", namespaceURI = SCL_NS_URI)
+        }
+)
 package org.lfenergy.compas.cim.mapping.rest.model;
 
 import javax.xml.bind.annotation.XmlNs;
 import javax.xml.bind.annotation.XmlSchema;
 
 import static org.lfenergy.compas.cim.mapping.Constants.CIM_MAPPING_SERVICE_NS_URI;
+import static org.lfenergy.compas.cim.mapping.Constants.SCL_NS_URI;

--- a/service/src/test/java/org/lfenergy/compas/cim/mapping/cgmes/CgmesDataValidatorTest.java
+++ b/service/src/test/java/org/lfenergy/compas/cim/mapping/cgmes/CgmesDataValidatorTest.java
@@ -33,8 +33,10 @@ class CgmesDataValidatorTest {
         var cimData2 = new CimData();
         cimData2.setName(expectedInString2);
 
+        var cimData = List.of(cimData1, cimData2);
+
         var exception = assertThrows(CompasValidationException.class,
-                () -> validator.validateData(List.of(cimData1, cimData2)));
+                () -> validator.validateData(cimData));
         assertTrue(exception.getMessage().contains(expectedInString1));
         assertTrue(exception.getMessage().contains(expectedInString2));
     }


### PR DESCRIPTION
It seems Quarkus fixed the bug when the prefix is blank "". In the latest version this works.