### PR TITLE
Changed configuration to fix building native image.

### DIFF
--- a/app/src/main/java/org/lfenergy/compas/cim/mapping/rest/CompasCimMappingConfiguration.java
+++ b/app/src/main/java/org/lfenergy/compas/cim/mapping/rest/CompasCimMappingConfiguration.java
@@ -15,14 +15,7 @@ import javax.enterprise.inject.Produces;
  * This is done by using the RegisterForReflection annotation.
  */
 @RegisterForReflection(targets = {
-        com.powsybl.triplestore.impl.rdf4j.TripleStoreFactoryServiceRDF4J.class,
-        org.lfenergy.compas.scl2007b4.model.ObjectFactory.class,
-        org.lfenergy.compas.scl2007b4.model.TDA.class,
-        org.lfenergy.compas.scl2007b4.model.TSDI.class,
-        org.lfenergy.compas.scl2007b4.model.TDAI.class,
-        javax.xml.bind.annotation.adapters.NormalizedStringAdapter.class,
-        javax.xml.bind.annotation.adapters.CollapsedStringAdapter.class,
-        javax.xml.bind.annotation.W3CDomHandler.class,
+        com.powsybl.triplestore.impl.rdf4j.TripleStoreFactoryServiceRDF4J.class
 })
 public class CompasCimMappingConfiguration {
     @Produces

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -11,6 +11,13 @@ quarkus.http.limits.max-body-size = 150M
 quarkus.log.level = INFO
 quarkus.log.category."org.lfenergy.compas.cim.mapping".level = INFO
 
+# Add scanning this dependency for scanning, also used by native compilation.
+quarkus.index-dependency.scl2007b4.group-id=org.lfenergy.compas.core
+quarkus.index-dependency.scl2007b4.artifact-id=scl2007b4
+
+quarkus.index-dependency.jaxb-api.group-id=org.jboss.spec.javax.xml.bind
+quarkus.index-dependency.jaxb-api.artifact-id=jboss-jaxb-api_2.3_spec
+
 # Settings needed for native compilation of the project.
 quarkus.native.resources.includes=**/com.powsybl.triplestore.api.TripleStoreFactoryService,CIM*.sparql
 quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.rdf4j.common.iteration.TimeLimitIteration,--initialize-at-run-time=org.apache.http.impl.auth.NTLMEngineImpl

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -11,7 +11,7 @@ quarkus.http.limits.max-body-size = 150M
 quarkus.log.level = INFO
 quarkus.log.category."org.lfenergy.compas.cim.mapping".level = INFO
 
-# Add scanning this dependency for scanning, also used by native compilation.
+# Add scanning these dependencies for scanning, also used by native compilation.
 quarkus.index-dependency.scl2007b4.group-id=org.lfenergy.compas.core
 quarkus.index-dependency.scl2007b4.artifact-id=scl2007b4
 


### PR DESCRIPTION
Added two artifacts for scanning for reflection needed for Native Build.
This way these 2 jars are scanned during building the Native image and the registration of the separate classes isn't needed anymore.