### PR TITLE
Simplified SparQL

### DIFF
--- a/MAPPING.md
+++ b/MAPPING.md
@@ -14,93 +14,93 @@ There is an IEC document describing the mapping, namely IEC/TS 62361-102, but no
 **Remark**: In CIM the name is optional, so when the name is not there the ID is used. This is the case for many
 entities described below (``name or id``).
 
-| CIM Class                        | IEC Class                        | Remark    |
-| -------------------------------- | -------------------------------- | --------- |
-| *cim:Substation*                 | *TSubstation*                    |           |
-| id                               | name                             |           |
-| name                             | desc                             |           |
-| List&lt;cim:VoltageLevel&gt;     | List&lt;TVoltageLevel&gt;        | (1)       |
-| List&lt;cim:PowerTransformer&gt; | List&lt;TPowerTransformer&gt;    |           |
+| CIM Class                        | IEC Class                     | Required | Remark |
+|----------------------------------|-------------------------------|----------|--------|
+| *cim:Substation*                 | *TSubstation*                 | -        |        |
+| id                               | name                          | Yes      |        |
+| name                             | desc                          | No       |        |
+| List&lt;cim:VoltageLevel&gt;     | List&lt;TVoltageLevel&gt;     | -        | (1)    |
+| List&lt;cim:PowerTransformer&gt; | List&lt;TPowerTransformer&gt; | -        |        |
 
 (1): The list of VoltageLevels that belong to the Substation.
 
-| CIM Class                        | IEC Class                        | Remark    |
-| -------------------------------- | -------------------------------- | --------- |
-| *cim:VoltageLevel*               | *TVoltageLevel*                  |           |
-| name or id                       | name                             |           |
-| '0'                              | nomFreq                          | (1)       |
-| nominalV                         | voltage.value                    |           |
-| 'k'                              | voltage.multiplier               |           |
-| 'V'                              | voltage.unit                     |           |
-| List&lt;cim:Bay&gt;              | List&lt;TBay&gt;                 | (2)       |
-| List&lt;cim:PowerTransformer&gt; | List&lt;TPowerTransformer&gt;    |           |
+| CIM Class                        | IEC Class                     | Required | Remark |
+|----------------------------------|-------------------------------|----------|--------|
+| *cim:VoltageLevel*               | *TVoltageLevel*               | -        |        |
+| name or id                       | name                          | Yes      |        |
+| '0'                              | nomFreq                       | -        | (1)    |
+| nominalV                         | voltage.value                 | No       |        |
+| 'k'                              | voltage.multiplier            | -        |        |
+| 'V'                              | voltage.unit                  | -        |        |
+| List&lt;cim:Bay&gt;              | List&lt;TBay&gt;              | -        | (2)    |
+| List&lt;cim:PowerTransformer&gt; | List&lt;TPowerTransformer&gt; | -        |        |
 
 (1): The nomFreq will be set to 0 if there is a Switch connected to it of the type 'DCLineSegment'.  
 (2): The list of Bays that belong to the VoltageLevel.
 
-| CIM Class                        | IEC Class                        | Remark    |
-| -------------------------------- | -------------------------------- | --------- |
-| *cim:BusbarSection*              | *TBay*                           |           |
-| name or id                       | name                             |           |
-| List&lt;cim:ConnectivityNode&gt; | List&lt;TConnectivityNode&gt;    | (1)       |
+| CIM Class                        | IEC Class                     | Required | Remark |
+|----------------------------------|-------------------------------|----------|--------|
+| *cim:BusbarSection*              | *TBay*                        | -        |        |
+| name or id                       | name                          | Yes      |        |
+| List&lt;cim:ConnectivityNode&gt; | List&lt;TConnectivityNode&gt; | -        | (1)    |
 
 (1): The ConnectivityNodes that are linked to the BusbarSection through a Terminal of the BusbarSection.
 
-| CIM Class                        | IEC Class                        | Remark    |
-| -------------------------------- | -------------------------------- | --------- |
-| *cim:Bay*                        | *TBay*                           |           |
-| name or id                       | name                             |           |
-| List&lt;cim:ConnectivityNode&gt; | List&lt;TConnectivityNode&gt;    | (1)       |
-| List&lt;*Switches*&gt;           | List&lt;TConductingEquipment&gt; | (2)       |
-| List&lt;cim:PowerTransformer&gt; | List&lt;TPowerTransformer&gt;    |           |
+| CIM Class                        | IEC Class                        | Required | Remark |
+|----------------------------------|----------------------------------|----------|--------|
+| *cim:Bay*                        | *TBay*                           | -        |        |
+| name or id                       | name                             | Yes      |        |
+| List&lt;cim:ConnectivityNode&gt; | List&lt;TConnectivityNode&gt;    | -        | (1)    |
+| List&lt;*Switches*&gt;           | List&lt;TConductingEquipment&gt; | -        | (2)    |
+| List&lt;cim:PowerTransformer&gt; | List&lt;TPowerTransformer&gt;    | -        |        |
 
 (1): The ConnectivityNodes that are linked to the Bay thought the terminals of the switches of the Bay.  
 (2): Switches in IEC CIM can be the following types, cim:Switch, cim:Breaker, cim:Disconnector, cim:LoadBreakSwitch and
 cim:ProtectedSwitch. These classes are all mapped in the same way on IEC 61850
 
-| CIM Class                           | IEC Class                        | Remark    |
-| ----------------------------------- | -------------------------------- | --------- |
-| *cim:PowerTransformer*              | *TPowerTransformer*              |           |
-| name or id                          | name                             |           |
-| description                         | desc                             |           |
-| 'PTR'                               | type                             |           |
-| List&lt;cim:PowerTransformerEnd&gt; | List&lt;TTransformerWinding&gt;  |           |
+| CIM Class                           | IEC Class                       | Required | Remark |
+|-------------------------------------|---------------------------------|----------|--------|
+| *cim:PowerTransformer*              | *TPowerTransformer*             | -        |        |
+| name or id                          | name                            | Yes      |        |
+| description                         | desc                            | No       |        |
+| 'PTR'                               | type                            | -        |        |
+| List&lt;cim:PowerTransformerEnd&gt; | List&lt;TTransformerWinding&gt; | -        |        |
 
-| CIM Class                        | IEC Class                        | Remark    |
-| -------------------------------- | -------------------------------- | --------- |
-| *cim:PowerTransformerEnd*        | *TTransformerWinding*            |           |
-| name or id (PowerTransformer) +  |                                  |           |
-| '_' + endNumber                  | name                             |           | 
-| 'PTW'                            | type                             |           |
-| cim:RatioTapChanger or           |                                  |           |
-| cim:PhaseTapChanger              | tapChanger                       |           |
-| Terminal                         | List&lt;TTerminal&gt;            | (1)       |
+| CIM Class                       | IEC Class             | Required | Remark |
+|---------------------------------|-----------------------|----------|--------|
+| *cim:PowerTransformerEnd*       | *TTransformerWinding* | -        |        |
+| name or id (PowerTransformer) + |                       |          |        |
+| '_' + endNumber                 | name                  | Yes      |        | 
+| 'PTW'                           | type                  | -        |        |
+| cim:RatioTapChanger or          |                       |          |        |
+| cim:PhaseTapChanger             | tapChanger            | -        |        |
+| Terminal                        | List&lt;TTerminal&gt; | -        | (1)    |
 
 (1): The terminal found in IEC CIM will be added as List to IEC 61850.
 
-| CIM Class                        | IEC Class                        | Remark    |
-| -------------------------------- | -------------------------------- | --------- |
-| *cim:RatioTapChanger* or         |                                  |           |
-| *cim:PhaseTapChanger*            | *TTapChanger*                    |           |
-| name or id                       | name                             |           |
-| 'LTC'                            | type                             |           |
+| CIM Class                | IEC Class     | Required | Remark |
+|--------------------------|---------------|----------|--------|
+| *cim:RatioTapChanger* or |               |          |        |
+| *cim:PhaseTapChanger*    | *TTapChanger* | -        |        |
+| name or id               | name          | Yes      |        |
+| 'LTC'                    | type          | -        |        |
 
-| CIM Class                        | IEC Class                        | Remark    |
-| -------------------------------- | -------------------------------- | --------- |
-| *cim:ConnectivityNode*           | *TConnectivityNode*              |           |
-| name or id                       | name                             |           |
-| -                                | pathName                         | (1)       |
+| CIM Class              | IEC Class           | Required | Remark |
+|------------------------|---------------------|----------|--------|
+| *cim:ConnectivityNode* | *TConnectivityNode* | -        |        |
+| name or id             | name                | Yes      |        |
+| -                      | pathName            | -        | (1)    |
 
 (1): The path name is derived from the names of all parent of that ConnectivityNode. In the context we keep a list of
 all Naming Elements we passed before coming to that ConnectivityNode. In this way we can build the PathName of that
 ConnectivityNode.
 
-| CIM Class                        | IEC Class                        | Remark    |
-| -------------------------------- | -------------------------------- | --------- |
-| *Switches*                       | *TConductingEquipment*           | (1)       |
-| name or id                       | name                             |           |
-| type                             | type                             | (2)       |
-| List&lt;cim:Terminal&gt;         | List&lt;TTerminal&gt;            | (3)       |
+| CIM Class                | IEC Class              | Required | Remark |
+|--------------------------|------------------------|----------|--------|
+| *Switches*               | *TConductingEquipment* | -        | (1)    |
+| name or id               | name                   | Yes      |        |
+| type                     | type                   | Yes      | (2)    |
+| List&lt;cim:Terminal&gt; | List&lt;TTerminal&gt;  | -        | (3)    |
 
 (1): Switches in IEC CIM can be the following types, cim:Switch cim:Breaker cim:Disconnector cim:LoadBreakSwitch cim:
 ProtectedSwitch.These classes are all mapped in the same way on IEC 61850  
@@ -108,52 +108,52 @@ ProtectedSwitch.These classes are all mapped in the same way on IEC 61850
 implements this mapping.  
 (3): The list of Terminal that belong to the Switch.
 
-| CIM Class                        | IEC Class                        | Remark    |
-| -------------------------------- | -------------------------------- | --------- |
-| *cim:Terminal*                   | *TTerminal*                      |           |
-| name or id                       | name                             |           |
-| -                                | connectivityNode                 | (1)       |
-| -                                | CNodeName                        | (1)       |
+| CIM Class      | IEC Class        | Required | Remark |
+|----------------|------------------|----------|--------|
+| *cim:Terminal* | *TTerminal*      | -        |        |
+| name or id     | name             | Yes      |        |
+| -              | connectivityNode | -        | (1)    |
+| -              | CNodeName        | -        | (1)    |
 
 (1): Use the ID of the ConnectivityNode to find the name or pathName of that ConnectivityNode. A map is saved of all
 ConnectivityNode that are processed for each Bay.
 
 ## Mapping from Cim Switch Type to IEC TConductingEquipment
 
-| IEC 61850 Type  | CIM Type              |
-| --------------- | --------------------- |
-| BSH             | Connector             |
-| CAB             | ACLineSegment         |
-| CAB             | DCLineSegment         |
-| CAP             | ShuntCompensator      |
-| CAP             | SeriesCompensator     |
-| CBR             | ProtectedSwitch       |
-| CBR             | Breaker               |
-| CBR             | Recloser              |
-| CON             | FrequencyConverter    |
-| CTR             | CurrentTransformer    |
-| DIS             | Switch                |
-| DIS             | Disconnector          |
-| DIS             | Fuse                  |
-| DIS             | Jumper                |
-| DIS             | LoadBreakSwitch       |
-| DIS             | GroundDisconnector    |
-| DIS             | Sectionaliser         |
-| EFN             | PetersenCoil          |
-| GEN             | GeneratingUnit        |
-| LTC             | TapChanger            |
-| LTC             | RatioTapChanger       |
-| LTC             | PhaseTapChanger       |
-| MOT             | AsynchronousMachine   |
-| PSH             | GroundingImpedance    |
-| PTR             | PowerTransformer      |
-| PTW             | TransformerEnd        |
-| PTW             | PowerTransformerEnd   |
-| PTW             | TransformerTankEnd    |
-| RES             | EarthFaultCompensator |
-| SAR             | SurgeArrester         |
-| SCR             | ACDCConverter         |
-| SMC             | SynchronousMachine    |
-| TCR             | StaticVarCompensator  |
-| TNK             | TransformerTank       |
-| VTR             | PotentialTransformer  |
+| IEC 61850 Type | CIM Type              |
+|----------------|-----------------------|
+| BSH            | Connector             |
+| CAB            | ACLineSegment         |
+| CAB            | DCLineSegment         |
+| CAP            | ShuntCompensator      |
+| CAP            | SeriesCompensator     |
+| CBR            | ProtectedSwitch       |
+| CBR            | Breaker               |
+| CBR            | Recloser              |
+| CON            | FrequencyConverter    |
+| CTR            | CurrentTransformer    |
+| DIS            | Switch                |
+| DIS            | Disconnector          |
+| DIS            | Fuse                  |
+| DIS            | Jumper                |
+| DIS            | LoadBreakSwitch       |
+| DIS            | GroundDisconnector    |
+| DIS            | Sectionaliser         |
+| EFN            | PetersenCoil          |
+| GEN            | GeneratingUnit        |
+| LTC            | TapChanger            |
+| LTC            | RatioTapChanger       |
+| LTC            | PhaseTapChanger       |
+| MOT            | AsynchronousMachine   |
+| PSH            | GroundingImpedance    |
+| PTR            | PowerTransformer      |
+| PTW            | TransformerEnd        |
+| PTW            | PowerTransformerEnd   |
+| PTW            | TransformerTankEnd    |
+| RES            | EarthFaultCompensator |
+| SAR            | SurgeArrester         |
+| SCR            | ACDCConverter         |
+| SMC            | SynchronousMachine    |
+| TCR            | StaticVarCompensator  |
+| TNK            | TransformerTank       |
+| VTR            | PotentialTransformer  |

--- a/service/src/main/java/org/lfenergy/compas/cim/mapping/mapper/CimToSclMapper.java
+++ b/service/src/main/java/org/lfenergy/compas/cim/mapping/mapper/CimToSclMapper.java
@@ -188,7 +188,7 @@ public abstract class CimToSclMapper {
                     tTransformerWinding.setTapChanger(tTapChanger);
                 });
 
-        context.getTerminal(transformerEnd.getTerminalId())
+        context.getTerminalById(transformerEnd.getTerminalId())
                 .ifPresent(cgmesTerminal -> {
                     var tTerminal = mapTerminalToTTerminal(cgmesTerminal, context);
                     tTransformerWinding.getTerminal().add(tTerminal);
@@ -230,7 +230,7 @@ public abstract class CimToSclMapper {
             tVoltageLevel.setNomFreq(BigDecimal.ZERO);
         }
 
-        context.getTerminals(cgmesSwitch.getId())
+        context.getTerminalsByConductingEquipment(cgmesSwitch.getId())
                 .stream()
                 .map(cgmesTerminal -> mapTerminalToTTerminal(cgmesTerminal, context))
                 .forEach(tTerminal -> tConductingEquipment.getTerminal().add(tTerminal));

--- a/service/src/main/java/org/lfenergy/compas/cim/mapping/mapper/CimToSclMapperContext.java
+++ b/service/src/main/java/org/lfenergy/compas/cim/mapping/mapper/CimToSclMapperContext.java
@@ -25,13 +25,13 @@ public class CimToSclMapperContext {
     public static final String SWITCH_PROP = "Switch";
     public static final String TERMINAL_PROP = "Terminal";
     public static final String CONNECTIVITY_NODE_PROP = "ConnectivityNode";
-    public static final String CONDUCTING_EQUIPMENT_PROP = "ConductingEquipment";
     public static final String EQUIPMENT_CONTAINER_PROP = "EquipmentContainer";
+
     public static final String NAME_PROP = "name";
     public static final String DESCRIPTION_PROP = "description";
     public static final String NOMINAL_VOLTAGE_PROP = "nominalVoltage";
     public static final String TYPE_PROP = "type";
-    public static final String ENDNUMBER_PROP = "endNumber";
+    public static final String END_NUMBER_PROP = "endNumber";
 
     private static final String START_QUERY = "SELECT *\nWHERE {{\n GRAPH ?graph {\n";
     private static final String END_QUERY = "}}}\n";
@@ -177,7 +177,7 @@ public class CimToSclMapperContext {
                         propertyBag.getId(TRANSFORMER_END_PROP),
                         propertyBag.get(NAME_PROP),
                         propertyBag.getId(TERMINAL_PROP),
-                        propertyBag.get(ENDNUMBER_PROP)))
+                        propertyBag.get(END_NUMBER_PROP)))
                 .collect(Collectors.toList());
     }
 

--- a/service/src/main/java/org/lfenergy/compas/cim/mapping/model/CgmesSwitch.java
+++ b/service/src/main/java/org/lfenergy/compas/cim/mapping/model/CgmesSwitch.java
@@ -5,15 +5,11 @@ package org.lfenergy.compas.cim.mapping.model;
 
 public class CgmesSwitch extends AbstractCgmesEntity {
     private String type;
-    private String terminal1Id;
-    private String terminal2Id;
 
-    public CgmesSwitch(String id, String name, String type, String terminal1Id, String terminal2Id) {
+    public CgmesSwitch(String id, String name, String type) {
         super(id, name);
 
         this.type = type;
-        this.terminal1Id = terminal1Id;
-        this.terminal2Id = terminal2Id;
     }
 
     public String getType() {
@@ -22,21 +18,5 @@ public class CgmesSwitch extends AbstractCgmesEntity {
 
     public void setType(String type) {
         this.type = type;
-    }
-
-    public String getTerminal1Id() {
-        return terminal1Id;
-    }
-
-    public void setTerminal1Id(String terminal1Id) {
-        this.terminal1Id = terminal1Id;
-    }
-
-    public String getTerminal2Id() {
-        return terminal2Id;
-    }
-
-    public void setTerminal2Id(String terminal2Id) {
-        this.terminal2Id = terminal2Id;
     }
 }

--- a/service/src/test/java/org/lfenergy/compas/cim/mapping/mapper/CimToSclMapperContextTest.java
+++ b/service/src/test/java/org/lfenergy/compas/cim/mapping/mapper/CimToSclMapperContextTest.java
@@ -43,9 +43,7 @@ class CimToSclMapperContextTest {
         bag.put(NAME_PROP, substationName);
         bags.add(bag);
 
-        var tripleStore = mock(TripleStore.class);
-        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
-        when(tripleStore.query(anyString())).thenReturn(bags);
+        setupTripleStore(bags);
 
         var result = context.getSubstations();
         assertNotNull(result);
@@ -69,9 +67,7 @@ class CimToSclMapperContextTest {
         bag.put(SUBSTATION_PROP, substationId);
         bags.add(bag);
 
-        var tripleStore = mock(TripleStore.class);
-        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
-        when(tripleStore.query(anyString())).thenReturn(bags);
+        setupTripleStore(bags);
 
         var result = context.getVoltageLevelsBySubstation(substationId);
         assertNotNull(result);
@@ -92,12 +88,9 @@ class CimToSclMapperContextTest {
         bag.put(NAME_PROP, busbarSectionName);
         bags.add(bag);
 
-        var tripleStore = mock(TripleStore.class);
-        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
-        when(tripleStore.query(anyString())).thenReturn(bags);
+        setupTripleStore(bags);
 
         var result = context.getBusbarSectionsByEquipmentContainer("Random VoltageId");
-
         assertNotNull(result);
         assertEquals(1, result.size());
         var busbarSection = result.get(0);
@@ -116,12 +109,9 @@ class CimToSclMapperContextTest {
         bag.put(NAME_PROP, bayName);
         bags.add(bag);
 
-        var tripleStore = mock(TripleStore.class);
-        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
-        when(tripleStore.query(anyString())).thenReturn(bags);
+        setupTripleStore(bags);
 
         var result = context.getBaysByVoltageLevel("Random VoltageId");
-
         assertNotNull(result);
         assertEquals(1, result.size());
         var bay = result.get(0);
@@ -144,12 +134,9 @@ class CimToSclMapperContextTest {
         bag.put(EQUIPMENT_CONTAINER_PROP, pwContainerId);
         bags.add(bag);
 
-        var tripleStore = mock(TripleStore.class);
-        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
-        when(tripleStore.query(anyString())).thenReturn(bags);
+        setupTripleStore(bags);
 
         var result = context.getTransformers(pwContainerId);
-
         assertNotNull(result);
         assertEquals(1, result.size());
         var transformer = result.get(0);
@@ -175,9 +162,7 @@ class CimToSclMapperContextTest {
         bag.put(ENDNUMBER_PROP, endNumber);
         bags.add(bag);
 
-        var tripleStore = mock(TripleStore.class);
-        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
-        when(tripleStore.query(anyString())).thenReturn(bags);
+        setupTripleStore(bags);
 
         var result = context.getTransformerEnds(tfId);
         assertNotNull(result);
@@ -197,9 +182,7 @@ class CimToSclMapperContextTest {
         var ratioBags = new PropertyBags();
         var phaseBags = new PropertyBags();
 
-        var tripleStore = mock(TripleStore.class);
-        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
-        when(tripleStore.query(anyString())).thenReturn(ratioBags, phaseBags);
+        setupTripleStore(ratioBags, phaseBags);
 
         var result = context.getTapChanger(tfeId);
         assertFalse(result.isPresent());
@@ -219,9 +202,7 @@ class CimToSclMapperContextTest {
         bag.put(TRANSFORMER_END_PROP, tfeId);
         ratioBags.add(bag);
 
-        var tripleStore = mock(TripleStore.class);
-        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
-        when(tripleStore.query(anyString())).thenReturn(ratioBags);
+        setupTripleStore(ratioBags);
 
         var result = context.getTapChanger(tfeId);
         assertTrue(result.isPresent());
@@ -245,9 +226,7 @@ class CimToSclMapperContextTest {
         bag.put(TRANSFORMER_END_PROP, tfeId);
         phaseBags.add(bag);
 
-        var tripleStore = mock(TripleStore.class);
-        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
-        when(tripleStore.query(anyString())).thenReturn(ratioBags, phaseBags);
+        setupTripleStore(ratioBags, phaseBags);
 
         var result = context.getTapChanger(tfeId);
         assertTrue(result.isPresent());
@@ -268,9 +247,7 @@ class CimToSclMapperContextTest {
         bag.put(NAME_PROP, ccnName);
         bags.add(bag);
 
-        var tripleStore = mock(TripleStore.class);
-        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
-        when(tripleStore.query(anyString())).thenReturn(bags);
+        setupTripleStore(bags);
 
         var result = context.getConnectivityNodeByBusbarSection(busbarSectionId);
         assertNotNull(result);
@@ -292,9 +269,7 @@ class CimToSclMapperContextTest {
         bag.put(NAME_PROP, ccnName);
         bags.add(bag);
 
-        var tripleStore = mock(TripleStore.class);
-        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
-        when(tripleStore.query(anyString())).thenReturn(bags);
+        setupTripleStore(bags);
 
         var result = context.getConnectivityNodeByBay(bayID);
         assertNotNull(result);
@@ -311,23 +286,14 @@ class CimToSclMapperContextTest {
         var containerId = "Known Container ID";
 
         var bags = new PropertyBags();
-        var bag = new PropertyBag(List.of(SWITCH_PROP, NAME_PROP, TYPE_PROP, EQUIPMENT_CONTAINER_PROP, TERMINAL_1_PROP, TERMINAL_2_PROP));
+        var bag = new PropertyBag(List.of(SWITCH_PROP, NAME_PROP, TYPE_PROP, EQUIPMENT_CONTAINER_PROP));
         bag.put(SWITCH_PROP, switchId);
         bag.put(NAME_PROP, switchName);
         bag.put(TYPE_PROP, "Breaker");
         bag.put(EQUIPMENT_CONTAINER_PROP, containerId);
-        bag.put(TERMINAL_1_PROP, "Terminal1 ID");
-        bag.put(TERMINAL_2_PROP, "Terminal2 ID");
         bags.add(bag);
 
-        bag = new PropertyBag(List.of(SWITCH_PROP, NAME_PROP, TYPE_PROP, EQUIPMENT_CONTAINER_PROP, TERMINAL_1_PROP, TERMINAL_2_PROP));
-        bag.put(SWITCH_PROP, "Other ID");
-        bag.put(NAME_PROP, "Other Name");
-        bag.put(TYPE_PROP, "Breaker");
-        bag.put(EQUIPMENT_CONTAINER_PROP, "Unknown Container ID");
-        bags.add(bag);
-
-        when(cgmesModel.switches()).thenReturn(bags);
+        setupTripleStore(bags);
 
         var result = context.getSwitches(containerId);
         assertNotNull(result);
@@ -338,30 +304,22 @@ class CimToSclMapperContextTest {
     }
 
     @Test
-    void getTerminals_WhenCalledWithKnownId_ThenPropertyBagsIsFilteredOnIdAndConvertedToCgmesTerminal() {
+    void getTerminalsByConductingEquipment_WhenCalledWithKnownId_ThenPropertyBagsIsFilteredOnIdAndConvertedToCgmesTerminal() {
         var terminalId = "TerminalId";
         var terminalName = "Name Terminal";
         var ccnNode = "Connectivity Node ID";
         var containerId = "Known Container ID";
 
         var bags = new PropertyBags();
-        var bag = new PropertyBag(List.of(TERMINAL_PROP, NAME_PROP, CONNECTIVITY_NODE_PROP, CONDUCTING_EQUIPMENT_PROP));
+        var bag = new PropertyBag(List.of(TERMINAL_PROP, NAME_PROP, CONNECTIVITY_NODE_PROP));
         bag.put(TERMINAL_PROP, terminalId);
         bag.put(NAME_PROP, terminalName);
         bag.put(CONNECTIVITY_NODE_PROP, ccnNode);
-        bag.put(CONDUCTING_EQUIPMENT_PROP, containerId);
         bags.add(bag);
 
-        bag = new PropertyBag(List.of(TERMINAL_PROP, NAME_PROP, CONNECTIVITY_NODE_PROP, CONDUCTING_EQUIPMENT_PROP));
-        bag.put(TERMINAL_PROP, "Other ID");
-        bag.put(NAME_PROP, "Other Name");
-        bag.put(CONNECTIVITY_NODE_PROP, "Some Other ID");
-        bag.put(CONDUCTING_EQUIPMENT_PROP, "Unknown Container ID");
-        bags.add(bag);
+        setupTripleStore(bags);
 
-        when(cgmesModel.terminals()).thenReturn(bags);
-
-        var result = context.getTerminals(containerId);
+        var result = context.getTerminalsByConductingEquipment(containerId);
         assertNotNull(result);
         assertEquals(1, result.size());
         var terminal = result.get(0);
@@ -370,31 +328,23 @@ class CimToSclMapperContextTest {
         assertEquals(ccnNode, terminal.getConnectivityNodeId());
     }
 
+
     @Test
-    void getTerminal_WhenCalledWithKnownId_ThenPropertyBagsIsFilteredOnIdAndConvertedToCgmesTerminal() {
+    void getTerminalById_WhenCalledWithKnownId_ThenPropertyBagsIsFilteredOnIdAndConvertedToCgmesTerminal() {
         var terminalId = "TerminalId";
         var terminalName = "Name Terminal";
         var ccnNode = "Connectivity Node ID";
-        var containerId = "Known Container ID";
 
         var bags = new PropertyBags();
-        var bag = new PropertyBag(List.of(TERMINAL_PROP, NAME_PROP, CONNECTIVITY_NODE_PROP, CONDUCTING_EQUIPMENT_PROP));
+        var bag = new PropertyBag(List.of(TERMINAL_PROP, NAME_PROP, CONNECTIVITY_NODE_PROP));
         bag.put(TERMINAL_PROP, terminalId);
         bag.put(NAME_PROP, terminalName);
         bag.put(CONNECTIVITY_NODE_PROP, ccnNode);
-        bag.put(CONDUCTING_EQUIPMENT_PROP, containerId);
         bags.add(bag);
 
-        bag = new PropertyBag(List.of(TERMINAL_PROP, NAME_PROP, CONNECTIVITY_NODE_PROP, CONDUCTING_EQUIPMENT_PROP));
-        bag.put(TERMINAL_PROP, "Other ID");
-        bag.put(NAME_PROP, "Other Name");
-        bag.put(CONNECTIVITY_NODE_PROP, "Some Other ID");
-        bag.put(CONDUCTING_EQUIPMENT_PROP, "Unknown Container ID");
-        bags.add(bag);
+        setupTripleStore(bags);
 
-        when(cgmesModel.terminals()).thenReturn(bags);
-
-        var result = context.getTerminal(terminalId);
+        var result = context.getTerminalById(terminalId);
         assertNotNull(result);
         var terminal = result.get();
         assertEquals(terminalId, terminal.getId());
@@ -509,5 +459,11 @@ class CimToSclMapperContextTest {
         var result = context.getNameFromConnectivityNode(cnId);
 
         assertFalse(result.isPresent());
+    }
+
+    private void setupTripleStore(PropertyBags bags, PropertyBags... otherBags) {
+        var tripleStore = mock(TripleStore.class);
+        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
+        when(tripleStore.query(anyString())).thenReturn(bags, otherBags);
     }
 }

--- a/service/src/test/java/org/lfenergy/compas/cim/mapping/mapper/CimToSclMapperContextTest.java
+++ b/service/src/test/java/org/lfenergy/compas/cim/mapping/mapper/CimToSclMapperContextTest.java
@@ -154,12 +154,12 @@ class CimToSclMapperContextTest {
         var endNumber = "1";
 
         var bags = new PropertyBags();
-        var bag = new PropertyBag(List.of(TRANSFORMER_END_PROP, NAME_PROP, POWER_TRANSFORMER_PROP, TERMINAL_PROP, ENDNUMBER_PROP));
+        var bag = new PropertyBag(List.of(TRANSFORMER_END_PROP, NAME_PROP, POWER_TRANSFORMER_PROP, TERMINAL_PROP, END_NUMBER_PROP));
         bag.put(TRANSFORMER_END_PROP, tfeId);
         bag.put(NAME_PROP, tfeName);
         bag.put(POWER_TRANSFORMER_PROP, tfId);
         bag.put(TERMINAL_PROP, terminalId);
-        bag.put(ENDNUMBER_PROP, endNumber);
+        bag.put(END_NUMBER_PROP, endNumber);
         bags.add(bag);
 
         setupTripleStore(bags);

--- a/service/src/test/java/org/lfenergy/compas/cim/mapping/mapper/CimToSclMapperContextTest.java
+++ b/service/src/test/java/org/lfenergy/compas/cim/mapping/mapper/CimToSclMapperContextTest.java
@@ -69,14 +69,9 @@ class CimToSclMapperContextTest {
         bag.put(SUBSTATION_PROP, substationId);
         bags.add(bag);
 
-        bag = new PropertyBag(List.of(VOLTAGE_LEVEL_PROP, NAME_PROP, NOMINAL_VOLTAGE_PROP, SUBSTATION_PROP));
-        bag.put(VOLTAGE_LEVEL_PROP, "Other ID");
-        bag.put(NAME_PROP, "Other Name");
-        bag.put(NOMINAL_VOLTAGE_PROP, "1.1");
-        bag.put(SUBSTATION_PROP, "Unknown Container ID");
-        bags.add(bag);
-
-        when(cgmesModel.voltageLevels()).thenReturn(bags);
+        var tripleStore = mock(TripleStore.class);
+        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
+        when(tripleStore.query(anyString())).thenReturn(bags);
 
         var result = context.getVoltageLevelsBySubstation(substationId);
         assertNotNull(result);
@@ -199,8 +194,12 @@ class CimToSclMapperContextTest {
     void getTapChanger_WhenNoTapChangersFound_ThenEmptyOptionalReturned() {
         var tfeId = "Known Transformer End ID";
 
-        when(cgmesModel.ratioTapChangers()).thenReturn(new PropertyBags());
-        when(cgmesModel.phaseTapChangers()).thenReturn(new PropertyBags());
+        var ratioBags = new PropertyBags();
+        var phaseBags = new PropertyBags();
+
+        var tripleStore = mock(TripleStore.class);
+        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
+        when(tripleStore.query(anyString())).thenReturn(ratioBags, phaseBags);
 
         var result = context.getTapChanger(tfeId);
         assertFalse(result.isPresent());
@@ -212,13 +211,17 @@ class CimToSclMapperContextTest {
         var tcName = "Name TapChanger";
         var tfeId = "Known Transformer End ID";
 
-        var bags = new PropertyBags();
+        var ratioBags = new PropertyBags();
+
         var bag = new PropertyBag(List.of(RATIO_TAP_CHANGER_PROP, NAME_PROP, TRANSFORMER_END_PROP));
         bag.put(RATIO_TAP_CHANGER_PROP, tcId);
         bag.put(NAME_PROP, tcName);
         bag.put(TRANSFORMER_END_PROP, tfeId);
-        bags.add(bag);
-        when(cgmesModel.ratioTapChangers()).thenReturn(bags);
+        ratioBags.add(bag);
+
+        var tripleStore = mock(TripleStore.class);
+        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
+        when(tripleStore.query(anyString())).thenReturn(ratioBags);
 
         var result = context.getTapChanger(tfeId);
         assertTrue(result.isPresent());
@@ -233,15 +236,18 @@ class CimToSclMapperContextTest {
         var tcName = "Name TapChanger";
         var tfeId = "Known Transformer End ID";
 
-        when(cgmesModel.ratioTapChangers()).thenReturn(new PropertyBags());
+        var ratioBags = new PropertyBags();
+        var phaseBags = new PropertyBags();
 
-        var bags = new PropertyBags();
         var bag = new PropertyBag(List.of(PHASE_TAP_CHANGER_PROP, NAME_PROP, TRANSFORMER_END_PROP));
         bag.put(PHASE_TAP_CHANGER_PROP, tcId);
         bag.put(NAME_PROP, tcName);
         bag.put(TRANSFORMER_END_PROP, tfeId);
-        bags.add(bag);
-        when(cgmesModel.phaseTapChangers()).thenReturn(bags);
+        phaseBags.add(bag);
+
+        var tripleStore = mock(TripleStore.class);
+        when(cgmesModel.tripleStore()).thenReturn(tripleStore);
+        when(tripleStore.query(anyString())).thenReturn(ratioBags, phaseBags);
 
         var result = context.getTapChanger(tfeId);
         assertTrue(result.isPresent());


### PR DESCRIPTION
Replace the ones used from CGMES with custom SparQL based on CGMES SparQL.

Mainly fixes issue #189, but also fixed issue #185, because the Terminal 1/Terminal 2 isn't used, so removed from the query.