### PR TITLE
Temporary stop building native docker images until bug fixed.

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -50,7 +50,9 @@ jobs:
           servers: '[{ "id": "github-packages-compas", "username": "OWNER", "password": "${{ secrets.GITHUB_TOKEN }}" }]'
       - name: Build Native with Maven
         if: ${{ github.event_name == 'pull_request' }}
-        run: ./mvnw -s custom_maven_settings.xml -B -Pnative clean verify
+        # See issue https://github.com/com-pas/compas-cim-mapping/issues/218
+        #        run: ./mvnw -s custom_maven_settings.xml -B -Pnative clean verify
+        run: ./mvnw -s custom_maven_settings.xml -B clean verify
       - name: Build with Maven
         if: ${{ github.event_name == 'push' }}
         run: ./mvnw -s custom_maven_settings.xml -B clean verify

--- a/.github/workflows/release-project.yml
+++ b/.github/workflows/release-project.yml
@@ -6,7 +6,7 @@ name: Release Project
 
 on:
   release:
-    types: [released]
+    types: [ released ]
 
 jobs:
   push_to_registry:
@@ -56,6 +56,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy with Maven to GitHub Packages and Docker Hub
-        run: ./mvnw -B -s custom_maven_settings.xml -Prelease,native clean deploy
+        # See issue https://github.com/com-pas/compas-cim-mapping/issues/218
+        #        run: ./mvnw -B -s custom_maven_settings.xml -Prelease,native clean deploy
+        run: ./mvnw -B -s custom_maven_settings.xml -Prelease clean deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ SPDX-License-Identifier: Apache-2.0
         <surefire-plugin.version>3.0.0-M6</surefire-plugin.version>
         <sonarqube-plugin.version>3.2.0</sonarqube-plugin.version>
 
-        <compas.core.version>0.8.0</compas.core.version>
+        <compas.core.version>0.9.0</compas.core.version>
 
         <quarkus.platform.version>2.8.2.Final</quarkus.platform.version>
         <microprofile-openapi-api.version>3.0</microprofile-openapi-api.version>


### PR DESCRIPTION
There seems to be a problem in the Quarkus JAXB2 Library regarding native docker images being build. 
We probably need to wait until a new version before we can start creating Native Docker Images again.
See #218 